### PR TITLE
chore: remove hard coded node path, add `.tool-versions`

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+nodejs 21.2.0
+ruby 3.3.5
+cocoapods 1.16.2

--- a/macos/.xcode.env.local
+++ b/macos/.xcode.env.local
@@ -1,1 +1,1 @@
-export NODE_BINARY=/Users/jh/.asdf/installs/nodejs/21.2.0/bin/node
+export NODE_BINARY=$(asdf which node)

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -5,9 +5,9 @@ PODS:
   - FBLazyVector (0.78.3)
   - fmt (11.0.2)
   - glog (0.3.5)
-  - hermes-engine (0.78.2):
-    - hermes-engine/Pre-built (= 0.78.2)
-  - hermes-engine/Pre-built (0.78.2)
+  - hermes-engine (0.78.3):
+    - hermes-engine/Pre-built (= 0.78.3)
+  - hermes-engine/Pre-built (0.78.3)
   - RCT-Folly (2024.11.18.00):
     - boost
     - DoubleConversion
@@ -1768,66 +1768,66 @@ SPEC CHECKSUMS:
   FBLazyVector: b61b46a4137164b884a21e2ae3e289e1ccef5700
   fmt: f6af2d677a106e3e44c9536a4c0c7f03ab53c854
   glog: b7594b792ee4e02ed1f44b01d046ca25fa713e3d
-  hermes-engine: 2771b98fb813fdc6f92edd7c9c0035ecabf9fee7
-  RCT-Folly: e8b53d8c0d2d9df4a6a8b0a368a1a91fc62a88cb
+  hermes-engine: b5c9cfbe6415f1b0b24759f2942c8f33e9af6347
+  RCT-Folly: abec2d7f4af402b4957c44e86ceff8725b23c1b4
   RCTDeprecation: cf39863b43871c2031050605fb884019b6193910
   RCTRequired: 8e45f166ea2d154c59dd209c5bb710ad3ac0e752
   RCTTypeSafety: 28651c7820ad239ac978b3a0cca1f1486a19408a
   React: e470b63f0ff02464f52a526d7989f533467e725a
   React-callinvoker: cdbf74bfa1e78c0a41d43bbd5f34b6e22e093368
-  React-Core: 1684399a46aab0311a8f49f4bf79f150fc3e857b
-  React-CoreModules: 598edc04279d73e2c77fb28f66e1189613abbbb0
-  React-cxxreact: 9c09c840fcc68fd1653097948538a4a00aadb32d
+  React-Core: 3cc4c4a445a9cd3f978d4fa78cf1f8635b372308
+  React-CoreModules: 9d20fb717d561d3d0379dad82745ac77c715e168
+  React-cxxreact: 0b1d18392c18ce6d4a48e8c19d70138dc25b1e40
   React-debug: 9ef45d64b88281e7e629158410ceb61b3bb51ea0
-  React-defaultsnativemodule: 96424c53bc2c1a95cd46a82721e48fbc419cf6a3
-  React-domnativemodule: 52497561d1d41a1473f3af344190eaf965d7840e
-  React-Fabric: 3885a3a9df5a8b9721b4d885efb747981fcf1697
-  React-FabricComponents: dcca1c3d298094084e5c1443e4e3dff60fce6629
-  React-FabricImage: 74916cc9ace11a9afaa9dae55c94aa4a2c919f92
+  React-defaultsnativemodule: a74c7431969c0b0066a64e11d678eb3f573c1d76
+  React-domnativemodule: e57c6b5c856bcf815a594fab30c9c5b8fb37d9a7
+  React-Fabric: 0573a6a2a8bd2225cf16b557974253161f43ef4e
+  React-FabricComponents: f9f0281ff05c7d575b1813ed737c290085972887
+  React-FabricImage: 006423218d6ff537a1211935fd5f44b60e4b8441
   React-featureflags: 46790800dbdeb1305b3b12427b4d18413dadd13e
-  React-featureflagsnativemodule: ac1ca4ab3f940095a8cff072b3a9498c33ea7f7a
-  React-graphics: d357f67f0879fe4099b0472b40afad974fc92a83
-  React-hermes: 3e069ff831164b14bdef27f287a0e38ae839b20e
-  React-idlecallbacksnativemodule: 3bdc8eb4128e7b44b466a47edd7ea808113aad87
-  React-ImageManager: d659fe11f416db79685d67c495d244f4e44991dc
-  React-jserrorhandler: 4baf417d7d2765828f8aeef5738144f4e434b666
-  React-jsi: 050999af2e0e5170997039f6bbf9e82377e279d7
-  React-jsiexecutor: 7d3fe25094a005c0d0c21f37e8191e4f4e50176b
-  React-jsinspector: 63e7f2dd4255391436586bd13b4f6a0c7b21632b
-  React-jsinspectortracing: 109fe07e7a33ccdf568f8847de417efa3b184592
-  React-jsitracing: e2e2feb11eb1e9a60ede7825d5454a159cc5bc96
-  React-logger: 403502d548fbc097ab2c5a783ca98f5e84390bad
-  React-Mapbuffer: 3815edc6553967769cdd5e9127284926416270f0
-  React-microtasksnativemodule: e6cb4584ab49af3ecb0c13b5909c9fe0ce969ea9
-  react-native-mmkv: c969437e688f281c34d90310d5e05bbd5f8732a1
-  React-NativeModulesApple: f3c2e2ce112c5f1cc4f163176924418d446a6e6a
-  React-perflogger: 3756bfe3ff8cc8fffed3c51dce34cef861d4b82a
-  React-performancetimeline: c4678b2226a660268cc478662ffc43a2ab1b5d30
+  React-featureflagsnativemodule: d2c7dea5fdf8264242d201198d128f151b02c0ef
+  React-graphics: 846b0aebf99c77da67a2161159d975bcc0828dc9
+  React-hermes: 9c10f8c1fb7d4a1d8acacf641092f85a1e3625d9
+  React-idlecallbacksnativemodule: 0b73fcb5e403bbc8bf396889b7842def4f3c6131
+  React-ImageManager: f5873fd1a035b0dfd30d84f6ed9f2fa6bf68ffcd
+  React-jserrorhandler: e874479261134c175ccb801109a0832f6ec2b70e
+  React-jsi: dd82aadb0af8d5bc29e14388c9764ce384d795c6
+  React-jsiexecutor: ad92c8beb79db5ac94a05b45da4833435a37baa4
+  React-jsinspector: a2a65f729d78c93bc97f59c5a1d16c0bf3826c2d
+  React-jsinspectortracing: 68be6b73d994951769538988f497b9fb45077431
+  React-jsitracing: 780c76a54f6f4935d135a6672d5e1d103b01378d
+  React-logger: 7692258489bc7f1fc9b27f65eb0ddcd80ede1aa1
+  React-Mapbuffer: e67b47b96890c68b3bf1277345e0bf3b43189ccb
+  React-microtasksnativemodule: a0019ae5a337de2fdb2bd9023297f63246061d1d
+  react-native-mmkv: a578df102150a1742d11e741b581bc63edef9771
+  React-NativeModulesApple: cf1ca7b8e6e75db09eaaf1d2d43459630b148c93
+  React-perflogger: 264dc0f53bd9ee0fd734106002b531966ecc3256
+  React-performancetimeline: d4f03d4699df0321c6303735cdede7f9dc6292a2
   React-RCTActionSheet: 411a6257051d5b24dc66704851cc9235f958e65a
-  React-RCTAnimation: c0197d1545a45ade3517f34271ec9c81b1aee5fd
-  React-RCTAppDelegate: c94c03ef7dfad0a446c4ecff6dc9252860cfc80e
-  React-RCTBlob: 23fd27a68f1f28fb3f3abf7b22a429a4d65fd9d9
-  React-RCTFabric: cccaa2f386b67512c80fdaf3e548d6fb7bf4c1e8
-  React-RCTFBReactNativeSpec: 99c54bd15b054a509b0fdc960f222b2683ab4fb2
-  React-RCTImage: c00be431cd5639cb63241d427ebb14593a82e5f7
-  React-RCTLinking: 0b0399a963b358af083c2b37a10ec542bfe7cd5d
-  React-RCTNetwork: ca3adfccdccf3898839832964fabea7106b7cd78
-  React-RCTSettings: f0df90a9db805c2a291d67ec0af0fbb6b1cb8f0e
-  React-RCTText: 6111a0d5fbd69455b99d710aaf2fb2e29d1d3a3a
-  React-RCTVibration: 93ac072f90ecc83871eac50ad6c51738d37e590e
+  React-RCTAnimation: c67f4637f01a3e2079afba0a55cb522eb5156076
+  React-RCTAppDelegate: 8d6486592b38c40191b548b84d64a2a6c9d44fad
+  React-RCTBlob: 222542e95b2b3737cf0a3ec5c96718ade8a5db15
+  React-RCTFabric: 1bc56590f16fee228398653874c377a334cbd6a0
+  React-RCTFBReactNativeSpec: 99ab0fb589bb70f02f6e1b158e1dc137d3c80453
+  React-RCTImage: 7f252b669d1a9a730a0f43f08e1af2d54129fc40
+  React-RCTLinking: e0860ec9f132e1d3701fd065076e730003fbc7d0
+  React-RCTNetwork: c604de4daff9e8c2e9171f82b5e7b6100d7b4f08
+  React-RCTSettings: d0540aeff36109b4caf2fc871d0f8558a0805a97
+  React-RCTText: db7e7bf3811ed182b81ef2458214c7aa8992f936
+  React-RCTVibration: 1c291931789c0803b9429f94c5d7a2e215aba3f3
   React-rendererconsistency: 007dccdd75e782d49834c68f0c412449048d40e4
-  React-rendererdebug: 019dc752d5de90475252347cc3d7897cd2a22521
+  React-rendererdebug: bab289a7c248c61d41f5f317013c1fe0dae467ad
   React-rncore: a8ffa6d315742a2bf13e628591368453dfdc3657
-  React-RuntimeApple: 9e5dcaa897cd16aeadfaeb7ced8ea4dd77926195
-  React-RuntimeCore: c4ab914b0498eda39f17d03618669f7572c4509c
+  React-RuntimeApple: beb34db74a1b9d08634609c89b78e0e2f366ab27
+  React-RuntimeCore: e8c71261118ef30213f9b8da6206d953700964e3
   React-runtimeexecutor: f7745ae40c91165e12293bdf48889ed85266b5e6
-  React-RuntimeHermes: 1f676783fb0b92bd75035d08fbab3abb06c5d057
-  React-runtimescheduler: ef1542b69b0fdd1121b430081c0617c93fbafe74
+  React-RuntimeHermes: a6aaca3dd31c834a3a1e02a8b587eaa97e895455
+  React-runtimescheduler: 18bdf3609267412f28f8c72c963307f3f4200a57
   React-timing: 603df0b59afb508934070c569cc568ef72778420
-  React-utils: 272bde9a8aa4037b23e2c9bf4b44e9a9a6cbdfaf
-  ReactAppDependencyProvider: a12262458b50521ba56afb93f4cc875732f9d643
-  ReactCodegen: 49edcd763d5eda0aced57c669784f0f618930b47
-  ReactCommon: 6da1953722466adfd0f0bdf5eb5f5551ff53aae1
+  React-utils: 4251de6f3e8e2fee8c763b3972c12d1de8143089
+  ReactAppDependencyProvider: dda2eca447ef13387ed59b9605382e036858c801
+  ReactCodegen: 2df8a34ed179b3ea6d848827f68e1bd4f8d49362
+  ReactCommon: 06d6013a960cfd9223a4f6d335343ce04c0edbbe
   SocketRocket: 03f7111df1a343b162bf5b06ead333be808e1e0a
   Yoga: f89a870053f1a8fbee8c98e35a1b9eff44ce2015
 


### PR DESCRIPTION
## Why

I tried building this locally on my machine and ran into a few hiccups. After these changes, I was able to build it locally.

## Does this work?

Works On My Machine™

<img width="1920" alt="Screenshot 2025-07-09 at 2 42 03 PM" src="https://github.com/user-attachments/assets/8a5a9e64-e524-42bc-a3b8-36afa9e7b204" />
