### PR TITLE
Add support for macOS context menus

### DIFF
--- a/app/components/ContextPressable.tsx
+++ b/app/components/ContextPressable.tsx
@@ -1,0 +1,67 @@
+import React, { useCallback } from "react"
+import { Pressable, type PressableProps, type GestureResponderEvent } from "react-native"
+import { useContextMenu, type ContextMenuConfig } from "../utils/useContextMenu" // adjust path
+
+/**
+ * # ContextPressable (macOS)
+ *
+ * A minimal wrapper around `Pressable` that also supports a native
+ * context menu on secondary click (right-click or ctrl-click). It wires into your
+ * `useContextMenu` hook and opens the menu at the cursor location.
+ *
+ * ## Props
+ * - `items`: The context menu structure (including nested children and `SEPARATOR`).
+ * - All other props are forwarded to the underlying `Pressable`.
+ *
+ * ## Behavior
+ * - **Primary click** behaves like a normal `Pressable` (`onPress`).
+ * - **Secondary click** (right-click) or **ctrl-click** opens the context menu.
+ * - Menu actions are resolved via the `useContextMenu` hook.
+ *
+ * ## Example
+ * ```tsx
+ * import { SEPARATOR } from "./useContextMenu"
+ *
+ * <ContextPressable
+ *   items={[
+ *     { label: "Open", action: () => console.log("Open") },
+ *     SEPARATOR,
+ *     {
+ *       label: "Share",
+ *       children: [
+ *         { label: "Copy Link", action: () => console.log("Copy Link") },
+ *         { label: "Email…", action: () => console.log("Email") },
+ *       ],
+ *     },
+ *     { label: "Delete", enabled: true, action: () => console.log("Delete") },
+ *   ]}
+ *   onPress={() => console.log("Primary press")}
+ *   style={{ padding: 12 }}
+ * >
+ *   {children}
+ * </ContextPressable>
+ * ```
+ */
+
+export interface ContextPressableProps extends PressableProps {
+  items: ContextMenuConfig["items"]
+}
+
+export function ContextPressable(props: ContextPressableProps) {
+  const { items, onPress, ...rest } = props
+  const { open } = useContextMenu({ items })
+
+  const handlePress = useCallback(
+    (e: GestureResponderEvent) => {
+      if ((e.nativeEvent as any).button === 2) {
+        return open()
+      }
+      if (onPress) onPress(e)
+    },
+    [open, onPress],
+  )
+
+  return <Pressable onPress={handlePress} {...rest} />
+}
+
+export default ContextPressable

--- a/app/components/TimelineItem.tsx
+++ b/app/components/TimelineItem.tsx
@@ -1,7 +1,7 @@
 import { Text, View, type ViewStyle, type TextStyle } from "react-native"
 import { useThemeName, withTheme } from "../theme/theme"
-import IRClipboard from "../native/IRClipboard/NativeIRClipboard"
 import ContextPressable from "./ContextPressable"
+import { MenuListEntry } from "../utils/useContextMenu"
 
 /**
  * A single item in the timeline.
@@ -22,6 +22,7 @@ type TimelineItemProps = {
   responseStatusCode?: number
   isSelected?: boolean
   onSelect?: () => void
+  contextMenu?: MenuListEntry[]
 }
 
 export function TimelineItem({
@@ -35,6 +36,7 @@ export function TimelineItem({
   responseStatusCode,
   isSelected = false,
   onSelect,
+  contextMenu,
 }: TimelineItemProps) {
   const [themeName] = useThemeName()
 
@@ -49,13 +51,7 @@ export function TimelineItem({
       <ContextPressable
         style={$pressableContainer(themeName)}
         onPress={handlePress}
-        items={[
-          {
-            label: "Copy",
-            action: () => IRClipboard.setString(title),
-            shortcut: "cmd+C",
-          },
-        ]}
+        items={contextMenu ?? []}
       >
         {/* Top Row: Title + Status + Time */}
         <View style={$topRow}>

--- a/app/components/TimelineItem.tsx
+++ b/app/components/TimelineItem.tsx
@@ -1,5 +1,7 @@
-import { Text, View, type ViewStyle, type TextStyle, Pressable } from "react-native"
+import { Text, View, type ViewStyle, type TextStyle } from "react-native"
 import { useThemeName, withTheme } from "../theme/theme"
+import IRClipboard from "../native/IRClipboard/NativeIRClipboard"
+import ContextPressable from "./ContextPressable"
 
 /**
  * A single item in the timeline.
@@ -44,7 +46,17 @@ export function TimelineItem({
 
   return (
     <View style={[$container(themeName), isSelected && $containerSelected(themeName)]}>
-      <Pressable style={$pressableContainer(themeName)} onPress={handlePress}>
+      <ContextPressable
+        style={$pressableContainer(themeName)}
+        onPress={handlePress}
+        items={[
+          {
+            label: "Copy",
+            action: () => IRClipboard.setString(title),
+            shortcut: "cmd+C",
+          },
+        ]}
+      >
         {/* Top Row: Title + Status + Time */}
         <View style={$topRow}>
           <View style={$leftSection}>
@@ -76,7 +88,7 @@ export function TimelineItem({
           </Text>
           {!!deltaTime && <Text style={$deltaText(themeName)}>+{deltaTime}ms</Text>}
         </View>
-      </Pressable>
+      </ContextPressable>
     </View>
   )
 }

--- a/app/components/TimelineLogItem.tsx
+++ b/app/components/TimelineLogItem.tsx
@@ -1,5 +1,7 @@
+import { MenuListEntry } from "app/utils/useContextMenu"
 import { TimelineItemLog } from "../types"
 import { TimelineItem } from "./TimelineItem"
+import IRClipboard from "../native/IRClipboard/NativeIRClipboard"
 
 type TimelineLogItemProps = {
   item: TimelineItemLog
@@ -32,6 +34,13 @@ export function TimelineLogItem({ item, isSelected = false, onSelect }: Timeline
   const preview =
     message.toString().substring(0, 100) + (message.toString().length > 100 ? "..." : "")
 
+  const contextMenu: MenuListEntry[] = [
+    {
+      label: "Copy Message",
+      action: () => IRClipboard.setString(message),
+    },
+  ]
+
   return (
     <TimelineItem
       title={level}
@@ -42,6 +51,7 @@ export function TimelineLogItem({ item, isSelected = false, onSelect }: Timeline
       isTagged={important}
       isSelected={isSelected}
       onSelect={onSelect}
+      contextMenu={contextMenu}
     />
   )
 }

--- a/app/components/TimelineNetworkItem.tsx
+++ b/app/components/TimelineNetworkItem.tsx
@@ -1,6 +1,8 @@
 import { TimelineItemNetwork } from "../types"
 import { TimelineItem } from "./TimelineItem"
 import { useTheme, useThemeName } from "../theme/theme"
+import type { MenuListEntry } from "../utils/useContextMenu"
+import IRClipboard from "../native/IRClipboard/NativeIRClipboard"
 
 type TimelineNetworkItemProps = {
   item: TimelineItemNetwork
@@ -64,21 +66,21 @@ export function TimelineNetworkItem({
     ? `${payload?.response?.status || ""} ${payload?.response?.statusText || ""}`
     : "UNKNOWN"
 
-  // TODO: move this into a context menu
-  // const toolbar = [
-  //   {
-  //     icon: ({ size }: { size: number }) => <Text style={{ fontSize: size }}>📋</Text>,
-  //     tip: "Copy to clipboard",
-  //     onClick: () => {
-  //       IRClipboard.setString(JSON.stringify(payload))
-  //     },
-  //   },
-  //   {
-  //     icon: ({ size }: { size: number }) => <Text style={{ fontSize: size }}>🔍</Text>,
-  //     tip: "Search similar",
-  //     onClick: () => console.log("Search similar"),
-  //   },
-  // ]
+  const contextMenu: MenuListEntry[] = [
+    {
+      label: "Copy",
+      children: [
+        {
+          label: "Copy Request",
+          action: () => IRClipboard.setString(JSON.stringify(payload?.request)),
+        },
+        {
+          label: "Copy Response",
+          action: () => IRClipboard.setString(JSON.stringify(payload?.response)),
+        },
+      ],
+    },
+  ]
 
   return (
     <TimelineItem
@@ -92,6 +94,7 @@ export function TimelineNetworkItem({
       responseStatusCode={responseStatusCode}
       isSelected={isSelected}
       onSelect={onSelect}
+      contextMenu={contextMenu}
     />
   )
 }

--- a/app/native/IRContextMenuManager/IRContextMenuManager.h
+++ b/app/native/IRContextMenuManager/IRContextMenuManager.h
@@ -1,0 +1,10 @@
+#import <AppSpec/AppSpec.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface IRContextMenuManager : NativeIRContextMenuManagerSpecBase <NativeIRContextMenuManagerSpec>
+@end
+
+NS_ASSUME_NONNULL_END
+
+

--- a/app/native/IRContextMenuManager/IRContextMenuManager.mm
+++ b/app/native/IRContextMenuManager/IRContextMenuManager.mm
@@ -64,13 +64,15 @@ RCT_EXPORT_MODULE()
     if (![entry isKindOfClass:[NSDictionary class]]) continue;
     NSDictionary *item = (NSDictionary *)entry;
     NSString *label = item[@"label"] ?: @"";
-    BOOL enabled = item[@"enabled"] ? [item[@"enabled"] boolValue] : YES;
+    BOOL enabled = item[@"enabled"] != nil ? [item[@"enabled"] boolValue] : YES;
+    BOOL checked = item[@"checked"] != nil ? [item[@"checked"] boolValue] : NO;
     NSString *shortcut = item[@"shortcut"] ?: @"";
     NSArray *children = item[@"children"];
 
-    NSMenuItem *menuItem = [[NSMenuItem alloc] initWithTitle:label action:@selector(_ir_menuItemPressed:) keyEquivalent:@""];
-    menuItem.target = self;
+    NSMenuItem *menuItem = [[NSMenuItem alloc] initWithTitle:label action:enabled ? @selector(_ir_menuItemPressed:) : nil keyEquivalent:@""];
+    menuItem.target = enabled ? self : nil;
     menuItem.enabled = enabled;
+    menuItem.state = checked ? NSControlStateValueOn : NSControlStateValueOff;
     if (shortcut.length > 0) {
       [self applyShortcut:shortcut toItem:menuItem];
     }

--- a/app/native/IRContextMenuManager/IRContextMenuManager.mm
+++ b/app/native/IRContextMenuManager/IRContextMenuManager.mm
@@ -1,0 +1,172 @@
+#import "IRContextMenuManager.h"
+#import <Cocoa/Cocoa.h>
+#import <React/RCTUtils.h>
+
+static NSString * const kSeparatorString = @"menu-item-separator";
+
+@implementation IRContextMenuManager
+
+RCT_EXPORT_MODULE()
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const facebook::react::ObjCTurboModule::InitParams &)params {
+  return std::make_shared<facebook::react::NativeIRContextMenuManagerSpecJSI>(params);
+}
+
+#pragma mark - API
+
+- (void)showContextMenu:(NSArray *)items {
+  RCTExecuteOnMainQueue(^{
+    [self presentContextMenuWithItems:items];
+  });
+}
+
+#pragma mark - Helpers
+
+- (void)presentContextMenuWithItems:(NSArray *)items {
+  NSMenu *menu = [[NSMenu alloc] initWithTitle:@""];
+
+  [self buildMenu:menu fromEntries:items path:@[]];
+
+  NSEvent *event = [NSEvent mouseEventWithType:NSEventTypeRightMouseDown
+                                       location:[self currentMouseLocation]
+                                  modifierFlags:0
+                                      timestamp:[[NSProcessInfo processInfo] systemUptime]
+                                   windowNumber:[[NSApp keyWindow] windowNumber]
+                                        context:nil
+                                    eventNumber:0
+                                     clickCount:1
+                                       pressure:1.0];
+
+  [NSMenu popUpContextMenu:menu withEvent:event forView:[[NSApp keyWindow] contentView]];
+}
+
+- (NSPoint)currentMouseLocation {
+  NSPoint screenPoint = [NSEvent mouseLocation];
+  
+  // Convert screen -> window coordinates for the key window
+  NSWindow *window = [NSApp keyWindow];
+  if (!window) {
+    return screenPoint; // best effort
+  }
+  
+  NSRect screenRect = NSMakeRect(screenPoint.x, screenPoint.y, 0, 0);
+  NSPoint windowPoint = [window convertRectFromScreen:screenRect].origin;
+  return windowPoint;
+}
+
+- (void)buildMenu:(NSMenu *)menu fromEntries:(NSArray *)entries path:(NSArray<NSString *> *)path {
+  for (id entry in entries) {
+    if ([entry isKindOfClass:[NSString class]] && [(NSString *)entry isEqualToString:kSeparatorString]) {
+      [menu addItem:[NSMenuItem separatorItem]];
+      continue;
+    }
+
+    if (![entry isKindOfClass:[NSDictionary class]]) continue;
+    NSDictionary *item = (NSDictionary *)entry;
+    NSString *label = item[@"label"] ?: @"";
+    BOOL enabled = item[@"enabled"] ? [item[@"enabled"] boolValue] : YES;
+    NSString *shortcut = item[@"shortcut"] ?: @"";
+    NSArray *children = item[@"children"];
+
+    NSMenuItem *menuItem = [[NSMenuItem alloc] initWithTitle:label action:@selector(_ir_menuItemPressed:) keyEquivalent:@""];
+    menuItem.target = self;
+    menuItem.enabled = enabled;
+    if (shortcut.length > 0) {
+      [self applyShortcut:shortcut toItem:menuItem];
+    }
+
+    NSArray<NSString *> *currentPath = ({
+      NSMutableArray *m = [path mutableCopy];
+      if (label) [m addObject:label];
+      [m copy];
+    });
+    menuItem.representedObject = currentPath;
+
+    if ([children isKindOfClass:[NSArray class]] && children.count > 0) {
+      NSMenu *submenu = [[NSMenu alloc] initWithTitle:label];
+      [self buildMenu:submenu fromEntries:children path:currentPath];
+      menuItem.submenu = submenu;
+    }
+
+    [menu addItem:menuItem];
+  }
+}
+
+- (NSString *)keyEquivalentForKeyName:(NSString *)keyName {
+  // Map common key names to their NSMenuItem key equivalents
+  static NSDictionary *keyMap = nil;
+  if (!keyMap) {
+    keyMap = @{
+      @"enter": @"\r",
+      @"return": @"\r", 
+      @"space": @" ",
+      @"tab": @"\t",
+      @"delete": @"\x08",
+      @"backspace": @"\x08",
+      @"escape": @"\x1b",
+      @"esc": @"\x1b",
+      @"up": @"\uF700",
+      @"down": @"\uF701", 
+      @"left": @"\uF702",
+      @"right": @"\uF703",
+      @"f1": @"\uF704",
+      @"f2": @"\uF705",
+      @"f3": @"\uF706",
+      @"f4": @"\uF707",
+      @"f5": @"\uF708",
+      @"f6": @"\uF709",
+      @"f7": @"\uF70A",
+      @"f8": @"\uF70B",
+      @"f9": @"\uF70C",
+      @"f10": @"\uF70D",
+      @"f11": @"\uF70E",
+      @"f12": @"\uF70F"
+    };
+  }
+  
+  // Check if it's a special key
+  NSString *mapped = keyMap[keyName];
+  if (mapped) {
+    return mapped;
+  }
+  
+  // For single character keys, return as-is if it's a valid single character
+  if (keyName.length == 1) {
+    return keyName;
+  }
+  
+  // Return empty string for unknown keys
+  return @"";
+}
+
+- (void)applyShortcut:(NSString *)shortcut toItem:(NSMenuItem *)item {
+  if (shortcut.length == 0) return;
+  NSArray<NSString *> *parts = [[shortcut lowercaseString] componentsSeparatedByString:@"+"]; 
+  if (parts.count == 0) return;
+
+  NSString *keyName = [parts lastObject] ?: @"";
+  NSEventModifierFlags mask = 0;
+  for (NSString *p in parts) {
+    if ([p isEqualToString:@"cmd"] || [p isEqualToString:@"command"]) mask |= NSEventModifierFlagCommand;
+    else if ([p isEqualToString:@"shift"]) mask |= NSEventModifierFlagShift;
+    else if ([p isEqualToString:@"alt"] || [p isEqualToString:@"option"]) mask |= NSEventModifierFlagOption;
+    else if ([p isEqualToString:@"ctrl"] || [p isEqualToString:@"control"]) mask |= NSEventModifierFlagControl;
+  }
+  
+  // Map key names to actual key equivalents
+  NSString *keyEquivalent = [self keyEquivalentForKeyName:keyName];
+  if (keyEquivalent.length > 0) {
+    item.keyEquivalent = keyEquivalent;
+    item.keyEquivalentModifierMask = mask;
+  }
+}
+
+- (void)_ir_menuItemPressed:(NSMenuItem *)sender {
+  NSArray<NSString *> *path = sender.representedObject;
+  if (![path isKindOfClass:[NSArray class]]) return;
+  [self emitOnContextMenuItemPressed:@{ @"menuPath": path }];
+}
+
+@end
+
+

--- a/app/native/IRContextMenuManager/NativeIRContextMenuManager.ts
+++ b/app/native/IRContextMenuManager/NativeIRContextMenuManager.ts
@@ -1,0 +1,32 @@
+import type { EventEmitter } from "react-native/Libraries/Types/CodegenTypes"
+import type { TurboModule } from "react-native"
+import { TurboModuleRegistry } from "react-native"
+
+// Keep this constant identical to the menu bar manager for familiarity
+export const SEPARATOR = "menu-item-separator" as const
+
+export interface ContextMenuItemPressedEvent {
+  // Path of labels leading to the clicked item, e.g. ["Copy", "As JSON"]
+  menuPath: string[]
+}
+
+// JS description of a context menu item (no functions passed to native)
+export interface ContextMenuItem {
+  label: string
+  shortcut?: string
+  enabled?: boolean
+  children?: ContextMenuListEntry[]
+}
+
+export type ContextMenuListEntry = ContextMenuItem | typeof SEPARATOR
+
+export interface Spec extends TurboModule {
+  // Show a native context menu at current mouse location
+  showContextMenu(items: ContextMenuListEntry[]): void
+
+  readonly onContextMenuItemPressed: EventEmitter<ContextMenuItemPressedEvent>
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>("IRContextMenuManager")
+
+

--- a/app/native/IRContextMenuManager/NativeIRContextMenuManager.ts
+++ b/app/native/IRContextMenuManager/NativeIRContextMenuManager.ts
@@ -15,6 +15,7 @@ export interface ContextMenuItem {
   label: string
   shortcut?: string
   enabled?: boolean
+  checked?: boolean
   children?: ContextMenuListEntry[]
 }
 

--- a/app/utils/useContextMenu.tsx
+++ b/app/utils/useContextMenu.tsx
@@ -14,6 +14,7 @@ export type MenuItem = {
   label: string
   shortcut?: string
   enabled?: boolean
+  checked?: boolean
   children?: MenuListEntry[]
   action?: () => AsyncableVoid
 }
@@ -32,6 +33,7 @@ type NativeMenuItem = {
   label: string
   shortcut?: string
   enabled?: boolean
+  checked?: boolean
   children?: NativeMenuListEntry[]
 }
 
@@ -61,7 +63,7 @@ export function useContextMenu(config: ContextMenuConfig) {
         }
 
         const item = entry as MenuItem
-        const { label, shortcut, enabled, children, action } = item
+        const { label, shortcut, enabled, checked, children, action } = item
 
         // Prefer explicit ids in the path; fall back to label if not provided
         const nodeId = item.id ?? label
@@ -80,6 +82,7 @@ export function useContextMenu(config: ContextMenuConfig) {
           label, // native UI shows labels, ids are just for our lookup
           shortcut,
           enabled,
+          checked,
           children: Array.isArray(children) ? build(children, path) : undefined,
         })
       }

--- a/app/utils/useContextMenu.tsx
+++ b/app/utils/useContextMenu.tsx
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useMemo, useRef } from "react"
+import NativeIRContextMenuManager, {
+  SEPARATOR,
+  type ContextMenuItemPressedEvent,
+} from "../native/IRContextMenuManager/NativeIRContextMenuManager"
+
+export { SEPARATOR }
+
+type AsyncableVoid = void | Promise<void>
+
+export type MenuItem = {
+  /** Optional stable id to avoid label collisions and ease i18n */
+  id?: string
+  label: string
+  shortcut?: string
+  enabled?: boolean
+  children?: MenuListEntry[]
+  action?: () => AsyncableVoid
+}
+
+export type MenuListEntry = MenuItem | typeof SEPARATOR
+
+export interface ContextMenuConfig {
+  items: MenuListEntry[]
+}
+
+// used to separate path components in the action map key
+const DELIM = "\x1F" // 0x1F is the ASCII record separator character
+const makeKey = (path: readonly string[]) => path.join(DELIM)
+
+type NativeMenuItem = {
+  label: string
+  shortcut?: string
+  enabled?: boolean
+  children?: NativeMenuListEntry[]
+}
+
+type NativeMenuListEntry = NativeMenuItem | typeof SEPARATOR
+
+export function useContextMenu(config: ContextMenuConfig) {
+  // We keep the latest actionMap in a ref so onPress doesn't resubscribe.
+  const actionsRef = useRef<Map<string, () => AsyncableVoid>>(new Map())
+
+  // Build both the sanitized items (for native) and the action map (for lookup) in one pass.
+  const { nativeItems, actionMap } = useMemo(() => {
+    const nextMap = new Map<string, () => AsyncableVoid>()
+
+    const build = (entries: MenuListEntry[], parent: string[] = []): NativeMenuListEntry[] => {
+      const out: NativeMenuListEntry[] = []
+
+      const pushEntry = (e: NativeMenuListEntry) => {
+        // prevent consecutive separators
+        if (e === SEPARATOR && out[out.length - 1] === SEPARATOR) return
+        out.push(e)
+      }
+
+      for (const entry of entries) {
+        if (entry === SEPARATOR) {
+          pushEntry(SEPARATOR)
+          continue
+        }
+
+        const item = entry as MenuItem
+        const { label, shortcut, enabled, children, action } = item
+
+        // Prefer explicit ids in the path; fall back to label if not provided
+        const nodeId = item.id ?? label
+        const path = [...parent, nodeId]
+
+        if (typeof action === "function") {
+          const key = makeKey(path)
+          if (__DEV__ && nextMap.has(key)) {
+            // Useful when two sibling items share id/label
+            console.warn(`Duplicate context-menu path: ${path.join(" > ")}`)
+          }
+          nextMap.set(key, action)
+        }
+
+        pushEntry({
+          label, // native UI shows labels, ids are just for our lookup
+          shortcut,
+          enabled,
+          children: Array.isArray(children) ? build(children, path) : undefined,
+        })
+      }
+
+      // trim trailing separator
+      while (out.length && out[out.length - 1] === SEPARATOR) out.pop()
+      // trim leading separator
+      while (out.length && out[0] === SEPARATOR) out.shift()
+
+      return out
+    }
+
+    const built = build(config.items)
+    return { nativeItems: built, actionMap: nextMap }
+  }, [config.items])
+
+  // Keep the latest map in a ref without changing onPress identity.
+  useEffect(() => {
+    actionsRef.current = actionMap
+  }, [actionMap])
+
+  const onPress = useCallback((evt: ContextMenuItemPressedEvent) => {
+    // evt.menuPath is assumed to mirror our id/label path; we support either.
+    const key = makeKey(evt.menuPath)
+    const action = actionsRef.current.get(key)
+    if (!action) return
+
+    try {
+      const maybePromise = action()
+      // catch errors from async actions
+      if (maybePromise && typeof (maybePromise as Promise<void>).then === "function") {
+        ;(maybePromise as Promise<void>).catch((err) => {
+          if (__DEV__) console.error("Context menu action rejected:", err)
+        })
+      }
+    } catch (err) {
+      if (__DEV__) console.error("Context menu action threw:", err)
+    }
+  }, [])
+
+  // Subscribe once; handler stays stable.
+  useEffect(() => {
+    const sub = NativeIRContextMenuManager.onContextMenuItemPressed(onPress)
+    return () => sub.remove()
+  }, [onPress])
+
+  const open = useCallback(() => {
+    NativeIRContextMenuManager.showContextMenu(nativeItems)
+  }, [nativeItems])
+
+  return { open }
+}

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1769,65 +1769,65 @@ SPEC CHECKSUMS:
   fmt: f6af2d677a106e3e44c9536a4c0c7f03ab53c854
   glog: b7594b792ee4e02ed1f44b01d046ca25fa713e3d
   hermes-engine: b5c9cfbe6415f1b0b24759f2942c8f33e9af6347
-  RCT-Folly: e8b53d8c0d2d9df4a6a8b0a368a1a91fc62a88cb
+  RCT-Folly: abec2d7f4af402b4957c44e86ceff8725b23c1b4
   RCTDeprecation: cf39863b43871c2031050605fb884019b6193910
   RCTRequired: 8e45f166ea2d154c59dd209c5bb710ad3ac0e752
   RCTTypeSafety: 28651c7820ad239ac978b3a0cca1f1486a19408a
   React: e470b63f0ff02464f52a526d7989f533467e725a
   React-callinvoker: cdbf74bfa1e78c0a41d43bbd5f34b6e22e093368
-  React-Core: 1684399a46aab0311a8f49f4bf79f150fc3e857b
-  React-CoreModules: 598edc04279d73e2c77fb28f66e1189613abbbb0
-  React-cxxreact: 9c09c840fcc68fd1653097948538a4a00aadb32d
+  React-Core: 3cc4c4a445a9cd3f978d4fa78cf1f8635b372308
+  React-CoreModules: 9d20fb717d561d3d0379dad82745ac77c715e168
+  React-cxxreact: 0b1d18392c18ce6d4a48e8c19d70138dc25b1e40
   React-debug: 9ef45d64b88281e7e629158410ceb61b3bb51ea0
-  React-defaultsnativemodule: 96424c53bc2c1a95cd46a82721e48fbc419cf6a3
-  React-domnativemodule: 52497561d1d41a1473f3af344190eaf965d7840e
-  React-Fabric: 3885a3a9df5a8b9721b4d885efb747981fcf1697
-  React-FabricComponents: dcca1c3d298094084e5c1443e4e3dff60fce6629
-  React-FabricImage: 74916cc9ace11a9afaa9dae55c94aa4a2c919f92
+  React-defaultsnativemodule: a74c7431969c0b0066a64e11d678eb3f573c1d76
+  React-domnativemodule: e57c6b5c856bcf815a594fab30c9c5b8fb37d9a7
+  React-Fabric: 0573a6a2a8bd2225cf16b557974253161f43ef4e
+  React-FabricComponents: f9f0281ff05c7d575b1813ed737c290085972887
+  React-FabricImage: 006423218d6ff537a1211935fd5f44b60e4b8441
   React-featureflags: 46790800dbdeb1305b3b12427b4d18413dadd13e
-  React-featureflagsnativemodule: ac1ca4ab3f940095a8cff072b3a9498c33ea7f7a
-  React-graphics: d357f67f0879fe4099b0472b40afad974fc92a83
-  React-hermes: 3e069ff831164b14bdef27f287a0e38ae839b20e
-  React-idlecallbacksnativemodule: 3bdc8eb4128e7b44b466a47edd7ea808113aad87
-  React-ImageManager: d659fe11f416db79685d67c495d244f4e44991dc
-  React-jserrorhandler: 4baf417d7d2765828f8aeef5738144f4e434b666
-  React-jsi: 050999af2e0e5170997039f6bbf9e82377e279d7
-  React-jsiexecutor: 7d3fe25094a005c0d0c21f37e8191e4f4e50176b
-  React-jsinspector: 63e7f2dd4255391436586bd13b4f6a0c7b21632b
-  React-jsinspectortracing: 109fe07e7a33ccdf568f8847de417efa3b184592
-  React-jsitracing: e2e2feb11eb1e9a60ede7825d5454a159cc5bc96
-  React-logger: 403502d548fbc097ab2c5a783ca98f5e84390bad
-  React-Mapbuffer: 3815edc6553967769cdd5e9127284926416270f0
-  React-microtasksnativemodule: e6cb4584ab49af3ecb0c13b5909c9fe0ce969ea9
-  react-native-mmkv: c969437e688f281c34d90310d5e05bbd5f8732a1
-  React-NativeModulesApple: f3c2e2ce112c5f1cc4f163176924418d446a6e6a
-  React-perflogger: 3756bfe3ff8cc8fffed3c51dce34cef861d4b82a
-  React-performancetimeline: c4678b2226a660268cc478662ffc43a2ab1b5d30
+  React-featureflagsnativemodule: d2c7dea5fdf8264242d201198d128f151b02c0ef
+  React-graphics: 846b0aebf99c77da67a2161159d975bcc0828dc9
+  React-hermes: 9c10f8c1fb7d4a1d8acacf641092f85a1e3625d9
+  React-idlecallbacksnativemodule: 0b73fcb5e403bbc8bf396889b7842def4f3c6131
+  React-ImageManager: f5873fd1a035b0dfd30d84f6ed9f2fa6bf68ffcd
+  React-jserrorhandler: e874479261134c175ccb801109a0832f6ec2b70e
+  React-jsi: dd82aadb0af8d5bc29e14388c9764ce384d795c6
+  React-jsiexecutor: ad92c8beb79db5ac94a05b45da4833435a37baa4
+  React-jsinspector: a2a65f729d78c93bc97f59c5a1d16c0bf3826c2d
+  React-jsinspectortracing: 68be6b73d994951769538988f497b9fb45077431
+  React-jsitracing: 780c76a54f6f4935d135a6672d5e1d103b01378d
+  React-logger: 7692258489bc7f1fc9b27f65eb0ddcd80ede1aa1
+  React-Mapbuffer: e67b47b96890c68b3bf1277345e0bf3b43189ccb
+  React-microtasksnativemodule: a0019ae5a337de2fdb2bd9023297f63246061d1d
+  react-native-mmkv: a578df102150a1742d11e741b581bc63edef9771
+  React-NativeModulesApple: cf1ca7b8e6e75db09eaaf1d2d43459630b148c93
+  React-perflogger: 264dc0f53bd9ee0fd734106002b531966ecc3256
+  React-performancetimeline: d4f03d4699df0321c6303735cdede7f9dc6292a2
   React-RCTActionSheet: 411a6257051d5b24dc66704851cc9235f958e65a
-  React-RCTAnimation: c0197d1545a45ade3517f34271ec9c81b1aee5fd
-  React-RCTAppDelegate: c94c03ef7dfad0a446c4ecff6dc9252860cfc80e
-  React-RCTBlob: 23fd27a68f1f28fb3f3abf7b22a429a4d65fd9d9
-  React-RCTFabric: cccaa2f386b67512c80fdaf3e548d6fb7bf4c1e8
-  React-RCTFBReactNativeSpec: 99c54bd15b054a509b0fdc960f222b2683ab4fb2
-  React-RCTImage: c00be431cd5639cb63241d427ebb14593a82e5f7
-  React-RCTLinking: 0b0399a963b358af083c2b37a10ec542bfe7cd5d
-  React-RCTNetwork: ca3adfccdccf3898839832964fabea7106b7cd78
-  React-RCTSettings: f0df90a9db805c2a291d67ec0af0fbb6b1cb8f0e
-  React-RCTText: 6111a0d5fbd69455b99d710aaf2fb2e29d1d3a3a
-  React-RCTVibration: 93ac072f90ecc83871eac50ad6c51738d37e590e
+  React-RCTAnimation: c67f4637f01a3e2079afba0a55cb522eb5156076
+  React-RCTAppDelegate: 8d6486592b38c40191b548b84d64a2a6c9d44fad
+  React-RCTBlob: 222542e95b2b3737cf0a3ec5c96718ade8a5db15
+  React-RCTFabric: 1bc56590f16fee228398653874c377a334cbd6a0
+  React-RCTFBReactNativeSpec: 99ab0fb589bb70f02f6e1b158e1dc137d3c80453
+  React-RCTImage: 7f252b669d1a9a730a0f43f08e1af2d54129fc40
+  React-RCTLinking: e0860ec9f132e1d3701fd065076e730003fbc7d0
+  React-RCTNetwork: c604de4daff9e8c2e9171f82b5e7b6100d7b4f08
+  React-RCTSettings: d0540aeff36109b4caf2fc871d0f8558a0805a97
+  React-RCTText: db7e7bf3811ed182b81ef2458214c7aa8992f936
+  React-RCTVibration: 1c291931789c0803b9429f94c5d7a2e215aba3f3
   React-rendererconsistency: 007dccdd75e782d49834c68f0c412449048d40e4
-  React-rendererdebug: 019dc752d5de90475252347cc3d7897cd2a22521
+  React-rendererdebug: bab289a7c248c61d41f5f317013c1fe0dae467ad
   React-rncore: a8ffa6d315742a2bf13e628591368453dfdc3657
-  React-RuntimeApple: 9e5dcaa897cd16aeadfaeb7ced8ea4dd77926195
-  React-RuntimeCore: c4ab914b0498eda39f17d03618669f7572c4509c
+  React-RuntimeApple: beb34db74a1b9d08634609c89b78e0e2f366ab27
+  React-RuntimeCore: e8c71261118ef30213f9b8da6206d953700964e3
   React-runtimeexecutor: f7745ae40c91165e12293bdf48889ed85266b5e6
-  React-RuntimeHermes: 1f676783fb0b92bd75035d08fbab3abb06c5d057
-  React-runtimescheduler: ef1542b69b0fdd1121b430081c0617c93fbafe74
+  React-RuntimeHermes: a6aaca3dd31c834a3a1e02a8b587eaa97e895455
+  React-runtimescheduler: 18bdf3609267412f28f8c72c963307f3f4200a57
   React-timing: 603df0b59afb508934070c569cc568ef72778420
-  React-utils: 272bde9a8aa4037b23e2c9bf4b44e9a9a6cbdfaf
-  ReactAppDependencyProvider: a12262458b50521ba56afb93f4cc875732f9d643
-  ReactCodegen: 2b6c7d7db8ed68c1ea03196967f3e7b389d9df7b
-  ReactCommon: 6da1953722466adfd0f0bdf5eb5f5551ff53aae1
+  React-utils: 4251de6f3e8e2fee8c763b3972c12d1de8143089
+  ReactAppDependencyProvider: dda2eca447ef13387ed59b9605382e036858c801
+  ReactCodegen: e1d3427331f03cca7b51b1a6fce7b18af6a3a396
+  ReactCommon: 06d6013a960cfd9223a4f6d335343ce04c0edbbe
   SocketRocket: 03f7111df1a343b162bf5b06ead333be808e1e0a
   Yoga: f89a870053f1a8fbee8c98e35a1b9eff44ce2015
 

--- a/macos/Reactotron.xcodeproj/project.pbxproj
+++ b/macos/Reactotron.xcodeproj/project.pbxproj
@@ -25,10 +25,12 @@
 		5D4F10822E4E8CF6001FD625 /* IRMenuItemManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D4F107F2E4E8CF6001FD625 /* IRMenuItemManager.h */; };
 		6135879D33EC07D3C9C18C4F /* IRFontList.mm in Sources */ = {isa = PBXBuildFile; fileRef = FE5AD41C3F8CD3A0D9F46BE4 /* IRFontList.mm */; };
 		831983FBC55C0EF9C65DB4A6 /* ProcessUtils.c in Sources */ = {isa = PBXBuildFile; fileRef = 4F3799E74F7D2A242D38CF99 /* ProcessUtils.c */; };
+		8452BE2DDA6CACEAD0B97421 /* IRContextMenuManager.h in Headers */ = {isa = PBXBuildFile; fileRef = F1B8EE7491BC29C0FD958267 /* IRContextMenuManager.h */; };
 		8C89EDFB05AECC058BEEAC9C /* IRRunShellCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F2D1656A299D91E2C36B57A /* IRRunShellCommand.h */; };
 		9920FF3904BE57AC0A9A7934 /* IRExperimental.h in Headers */ = {isa = PBXBuildFile; fileRef = CB9465B5B2AD9013E736115C /* IRExperimental.h */; };
 		9A857687D246FD7F334FDC01 /* IRTabComponentView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3E5D5071E456C105AE0E1403 /* IRTabComponentView.mm */; };
 		A653779FBFCA255610039FB6 /* IRClipboard.mm in Sources */ = {isa = PBXBuildFile; fileRef = EC54A43A8D4051B988452A9D /* IRClipboard.mm */; };
+		A722680BDEF99E4DCC860711 /* IRContextMenuManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = 80F4F6B022222070325D08AD /* IRContextMenuManager.mm */; };
 		D2EAB5E25ECD9A5F2B8B5C67 /* IRRandom.mm in Sources */ = {isa = PBXBuildFile; fileRef = AC5E60FBAA17E2908A99A86D /* IRRandom.mm */; };
 		E6D143E50CDB44E4EF4F6317 /* IRTabComponentView.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A1F3D336FBDB9DFE36BC4F4 /* IRTabComponentView.h */; };
 		E94E8A1F2DA73754008B52A6 /* SpaceGrotesk.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E94E8A1E2DA73754008B52A6 /* SpaceGrotesk.ttf */; };
@@ -59,6 +61,7 @@
 		5D4F107F2E4E8CF6001FD625 /* IRMenuItemManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = IRMenuItemManager.h; path = ../app/native/IRMenuItemManager/IRMenuItemManager.h; sourceTree = SOURCE_ROOT; };
 		5D4F10802E4E8CF6001FD625 /* IRMenuItemManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = IRMenuItemManager.mm; path = ../app/native/IRMenuItemManager/IRMenuItemManager.mm; sourceTree = SOURCE_ROOT; };
 		7A78195A4E34D4BD895B11B6 /* IRRandom.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IRRandom.h; path = ../build/generated/colocated/IRRandom.h; sourceTree = "<group>"; };
+		80F4F6B022222070325D08AD /* IRContextMenuManager.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = IRContextMenuManager.mm; path = ../../app/native/IRContextMenuManager/IRContextMenuManager.mm; sourceTree = "<group>"; };
 		8940E9CE29AC22E267563A45 /* IRSystemInfo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IRSystemInfo.h; path = ../build/generated/colocated/IRSystemInfo.h; sourceTree = "<group>"; };
 		8B174B7FD8393A730D51E178 /* ProcessUtils.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ProcessUtils.h; path = ../../app/native/ProcessUtils/ProcessUtils.h; sourceTree = "<group>"; };
 		9710711BB1E9A76275DB3F3D /* IRSystemInfo.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = IRSystemInfo.mm; path = ../../app/native/IRSystemInfo/IRSystemInfo.mm; sourceTree = "<group>"; };
@@ -71,6 +74,7 @@
 		E94E8A1E2DA73754008B52A6 /* SpaceGrotesk.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = SpaceGrotesk.ttf; path = ../assets/fonts/SpaceGrotesk.ttf; sourceTree = SOURCE_ROOT; };
 		EC54A43A8D4051B988452A9D /* IRClipboard.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = IRClipboard.mm; path = ../../app/native/IRClipboard/IRClipboard.mm; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		F1B8EE7491BC29C0FD958267 /* IRContextMenuManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IRContextMenuManager.h; path = ../../app/native/IRContextMenuManager/IRContextMenuManager.h; sourceTree = "<group>"; };
 		F84D6E4D0800659BD68D7BF3 /* libPods-Reactotron-macOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Reactotron-macOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FAD97D6826CB49759F99BC4D /* IRRunShellCommand.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = IRRunShellCommand.mm; path = ../../app/native/IRRunShellCommand/IRRunShellCommand.mm; sourceTree = "<group>"; };
 		FE5AD41C3F8CD3A0D9F46BE4 /* IRFontList.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; name = IRFontList.mm; path = ../../app/native/IRFontList/IRFontList.mm; sourceTree = "<group>"; };
@@ -175,6 +179,8 @@
 				AC5E60FBAA17E2908A99A86D /* IRRandom.mm */,
 				9F2D1656A299D91E2C36B57A /* IRRunShellCommand.h */,
 				8940E9CE29AC22E267563A45 /* IRSystemInfo.h */,
+				F1B8EE7491BC29C0FD958267 /* IRContextMenuManager.h */,
+				80F4F6B022222070325D08AD /* IRContextMenuManager.mm */,
 			);
 			name = Colocated;
 			sourceTree = "<group>";
@@ -197,6 +203,7 @@
 				5CD63D88AE8814909F53CBFB /* IRRandom.h in Headers */,
 				8C89EDFB05AECC058BEEAC9C /* IRRunShellCommand.h in Headers */,
 				F29FD1592CD668F17E7C6D8C /* IRSystemInfo.h in Headers */,
+				8452BE2DDA6CACEAD0B97421 /* IRContextMenuManager.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -378,6 +385,7 @@
 				9A857687D246FD7F334FDC01 /* IRTabComponentView.mm in Sources */,
 				831983FBC55C0EF9C65DB4A6 /* ProcessUtils.c in Sources */,
 				D2EAB5E25ECD9A5F2B8B5C67 /* IRRandom.mm in Sources */,
+				A722680BDEF99E4DCC860711 /* IRContextMenuManager.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
### Summary
This PR adds support for context menus. The only features supported for now are:

- Enable/Disable items
- Check items
- Nested items
- Separators 

I figured we could add support for more features as-needed

### Changes

- Adds a Context Menu native module
- Adds useContextMenu hook and ContextPressable component
- Support for passing context menu items to TimelineItem component
- Adds copying functionality to the TimelineNetworkItem and TimelineLogItem components