### PR TITLE
feat: custom titlebar

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -11,6 +11,7 @@ import { useEffect } from "react"
 import { TimelineScreen } from "./screens/TimelineScreen"
 import { AppHeader } from "./components/AppHeader"
 import { useMenuItem } from "./utils/useMenuItem"
+import { Titlebar } from "./components/Titlebar"
 
 if (__DEV__) {
   // This is for debugging Reactotron with ... Reactotron!
@@ -41,8 +42,14 @@ function App(): React.JSX.Element {
   // and handle all websocket events.
   useEffect(() => connectToServer(), [])
 
+  // useEffect(() => {
+  //   NativeIRTitlebar.setupTitlebar()
+  //   NativeIRTitlebar.setTrafficLightPosition(12, 26)
+  // }, [])
+
   return (
     <View style={$container(theme)}>
+      <Titlebar />
       <StatusBar barStyle={"dark-content"} backgroundColor={colors.background} />
       <AppHeader />
       <View style={$contentContainer(theme)}>

--- a/app/app.tsx
+++ b/app/app.tsx
@@ -42,11 +42,6 @@ function App(): React.JSX.Element {
   // and handle all websocket events.
   useEffect(() => connectToServer(), [])
 
-  // useEffect(() => {
-  //   NativeIRTitlebar.setupTitlebar()
-  //   NativeIRTitlebar.setTrafficLightPosition(12, 26)
-  // }, [])
-
   return (
     <View style={$container(theme)}>
       <Titlebar />

--- a/app/components/Titlebar.tsx
+++ b/app/components/Titlebar.tsx
@@ -1,0 +1,32 @@
+import { useTheme, useThemeName, withTheme } from "../theme/theme"
+import { Platform, View, ViewStyle } from "react-native"
+
+export const Titlebar = () => {
+  const [themeName] = useThemeName()
+
+  return (
+    <View style={$container(themeName)}>
+      <TrafficLightSpacer />
+    </View>
+  )
+}
+
+const TrafficLightSpacer = () => {
+  return Platform.select({
+    // 🚥 Keep the content off the traffic lights in macos
+    macos: <View style={$macOSTrafficSpacer} />,
+    default: null, // TODO: Figure out how to handle this for Windows
+  })
+}
+
+const $container = withTheme<ViewStyle>((theme) => ({
+  backgroundColor: theme.colors.cardBackground,
+  paddingHorizontal: theme.spacing.sm,
+  flexDirection: "row",
+  alignItems: "center",
+  height: 36,
+}))
+
+const $macOSTrafficSpacer = {
+  width: 52,
+}

--- a/macos/Reactotron-macOS/AppDelegate.mm
+++ b/macos/Reactotron-macOS/AppDelegate.mm
@@ -22,6 +22,7 @@
   self.dependencyProvider = [RCTAppDependencyProvider new];
 
   [super applicationDidFinishLaunching:notification];
+  
   // Configure window chrome before RN mounts
   IRConfigureWindow(self.window);
 }

--- a/macos/Reactotron-macOS/AppDelegate.mm
+++ b/macos/Reactotron-macOS/AppDelegate.mm
@@ -3,6 +3,7 @@
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTDevloadingViewSetEnabled.h>
 #import <ReactAppDependencyProvider/RCTAppDependencyProvider.h>
+#import "WindowSetup.h"
 
 @implementation AppDelegate
 
@@ -20,7 +21,9 @@
   // Enable Fabric views
   self.dependencyProvider = [RCTAppDependencyProvider new];
 
-  return [super applicationDidFinishLaunching:notification];
+  [super applicationDidFinishLaunching:notification];
+  // Configure window chrome before RN mounts
+  IRConfigureWindow(self.window);
 }
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge

--- a/macos/Reactotron-macOS/WindowSetup.h
+++ b/macos/Reactotron-macOS/WindowSetup.h
@@ -1,0 +1,101 @@
+#import <Cocoa/Cocoa.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// One-time window configuration (titlebar style and traffic light position).
+// Header-only implementation so it can be used without adding a new build file.
+//
+// Summary:
+// - Enable full-size content titlebar for a unified look
+// - Position traffic lights relative to the titlebar container's top-left
+// - Preserve native spacing between buttons
+// - Lock intrinsic sizes to prevent future layout passes from squishing them
+// Finds the private titlebar container by walking up from a standard button.
+static inline NSView *_IRTitlebarContainer(NSWindow *w) {
+  NSView *btn = [w standardWindowButton:NSWindowCloseButton];
+  return btn ? (btn.superview.superview ?: btn.superview) : nil;
+}
+
+// One-time window chrome configuration (run before RN mounts).
+static inline void IRConfigureWindow(NSWindow * _Nullable window) {
+  if (!window) return;
+
+  // Enable full-size content titlebar (content underlays titlebar).
+  window.titleVisibility = NSWindowTitleHidden;
+  window.titlebarAppearsTransparent = YES;
+  window.styleMask |= NSWindowStyleMaskFullSizeContentView;
+  if (@available(macOS 11.0, *)) {
+    window.toolbarStyle = NSWindowToolbarStyleUnified;
+    window.titlebarSeparatorStyle = NSTitlebarSeparatorStyleAutomatic;
+  }
+
+  // Desired traffic light position (from the titlebar container's top-left).
+  const CGFloat x = 11.0;
+  const CGFloat y = 11.0;
+
+  NSView *tb = _IRTitlebarContainer(window);
+  if (!tb) return;
+
+  NSButton *closeB = [window standardWindowButton:NSWindowCloseButton];
+  NSButton *miniB  = [window standardWindowButton:NSWindowMiniaturizeButton];
+  NSButton *zoomB  = [window standardWindowButton:NSWindowZoomButton];
+  if (!closeB || !miniB || !zoomB) return;
+
+  // Preserve current native horizontal spacing between the buttons.
+  const CGFloat dx1 = NSMinX(miniB.frame) - NSMinX(closeB.frame);
+  const CGFloat dx2 = NSMinX(zoomB.frame) - NSMinX(miniB.frame);
+
+  // Remove any previous constraints we might have applied.
+  auto removeConstraintsFor = ^(NSView *v) {
+    NSMutableArray<NSLayoutConstraint *> *toRemove = [NSMutableArray array];
+    for (NSLayoutConstraint *c in v.constraints) {
+      if (c.firstItem == v || c.secondItem == v) {
+        [toRemove addObject:c];
+      }
+    }
+    for (NSLayoutConstraint *c in tb.constraints) {
+      if (c.firstItem == v || c.secondItem == v) {
+        [toRemove addObject:c];
+      }
+    }
+    for (NSLayoutConstraint *c in toRemove) {
+      [c setActive:NO];
+      if ([v.constraints containsObject:c]) [v removeConstraint:c];
+      if ([tb.constraints containsObject:c]) [tb removeConstraint:c];
+    }
+  };
+
+  removeConstraintsFor(closeB);
+  removeConstraintsFor(miniB);
+  removeConstraintsFor(zoomB);
+
+  // Opt into Auto Layout for these views.
+  closeB.translatesAutoresizingMaskIntoConstraints = NO;
+  miniB.translatesAutoresizingMaskIntoConstraints  = NO;
+  zoomB.translatesAutoresizingMaskIntoConstraints  = NO;
+
+  // Pin close button to top-left; keep others offset by native spacing.
+  NSLayoutConstraint *c1 = [closeB.leadingAnchor constraintEqualToAnchor:tb.leadingAnchor constant:x];
+  NSLayoutConstraint *c2 = [closeB.topAnchor constraintEqualToAnchor:tb.topAnchor constant:y];
+  NSLayoutConstraint *m1 = [miniB.leadingAnchor constraintEqualToAnchor:closeB.leadingAnchor constant:dx1];
+  NSLayoutConstraint *m2 = [miniB.topAnchor constraintEqualToAnchor:closeB.topAnchor];
+  NSLayoutConstraint *z1 = [zoomB.leadingAnchor constraintEqualToAnchor:miniB.leadingAnchor constant:dx2];
+  NSLayoutConstraint *z2 = [zoomB.topAnchor constraintEqualToAnchor:closeB.topAnchor];
+
+  // Lock intrinsic sizes so buttons never get squished by later layout passes.
+  NSSize closeSize = closeB.intrinsicContentSize;
+  NSSize miniSize  = miniB.intrinsicContentSize;
+  NSSize zoomSize  = zoomB.intrinsicContentSize;
+  NSLayoutConstraint *cw = [closeB.widthAnchor constraintEqualToConstant:closeSize.width];
+  NSLayoutConstraint *ch = [closeB.heightAnchor constraintEqualToConstant:closeSize.height];
+  NSLayoutConstraint *mw = [miniB.widthAnchor  constraintEqualToConstant:miniSize.width];
+  NSLayoutConstraint *mh = [miniB.heightAnchor constraintEqualToConstant:miniSize.height];
+  NSLayoutConstraint *zw = [zoomB.widthAnchor  constraintEqualToConstant:zoomSize.width];
+  NSLayoutConstraint *zh = [zoomB.heightAnchor constraintEqualToConstant:zoomSize.height];
+
+  [NSLayoutConstraint activateConstraints:@[c1, c2, m1, m2, z1, z2, cw, ch, mw, mh, zw, zh]];
+}
+
+NS_ASSUME_NONNULL_END
+
+

--- a/macos/Reactotron-macOS/WindowSetup.h
+++ b/macos/Reactotron-macOS/WindowSetup.h
@@ -10,6 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 // - Position traffic lights relative to the titlebar container's top-left
 // - Preserve native spacing between buttons
 // - Lock intrinsic sizes to prevent future layout passes from squishing them
+
 // Finds the private titlebar container by walking up from a standard button.
 static inline NSView *_IRTitlebarContainer(NSWindow *w) {
   NSView *btn = [w standardWindowButton:NSWindowCloseButton];
@@ -49,9 +50,7 @@ static inline void IRConfigureWindow(NSWindow * _Nullable window) {
   auto removeConstraintsFor = ^(NSView *v) {
     NSMutableArray<NSLayoutConstraint *> *toRemove = [NSMutableArray array];
     for (NSLayoutConstraint *c in v.constraints) {
-      if (c.firstItem == v || c.secondItem == v) {
-        [toRemove addObject:c];
-      }
+      if (c.firstItem == v || c.secondItem == v) [toRemove addObject:c];
     }
     for (NSLayoutConstraint *c in tb.constraints) {
       if (c.firstItem == v || c.secondItem == v) {


### PR DESCRIPTION
## Summary

This is the result of a lot of trial and error. I explored multiple ways to add a custom titlebar, but I believe this one comes with the most manageable tradeoffs. The runner up was to add a native module that would allow us to build the titlebar with [accessory views](https://developer.apple.com/documentation/appkit/nstitlebaraccessoryviewcontroller), but found that the complexity that it added would only compound once we add support for Windows. 

This PR takes a similar approach to the way that [electron allows for custom titlebars](https://www.electronjs.org/docs/latest/tutorial/custom-title-bar) (shout out to @joshuayoes for the suggestion), by making the titlebar full size and allowing us to position the macOS traffic lights by providing x & y coordinates in macos/Reactotron-macOS/WindowSetup.h.

## Motivation

The main motivation behind this change was to be able to add our sidebar collapse button beside the traffic lights to match the convention of many macOS application. However, this also adds the benefit of making the titlebar responsive to theme changes.

## Changes
[macos/Reactotron-macOS/AppDelegate.mm](https://github.com/infinitered/reactotron-macos/compare/feature/custom-titlebar?expand=1#diff-1ef8042cde252a322f0a74d11b960cbb9ce63af52c293ac2070476c632037429) - A script to enable a full size titlebar and position the traffic lights
[macos/Reactotron-macOS/AppDelegate.mm](https://github.com/infinitered/reactotron-macos/compare/feature/custom-titlebar?expand=1#diff-1ef8042cde252a322f0a74d11b960cbb9ce63af52c293ac2070476c632037429) - Adds the call to set up our window before React Native loads 
[app/components/Titlebar.tsx](https://github.com/infinitered/reactotron-macos/compare/feature/custom-titlebar?expand=1#diff-7e1fef46761ca14a29dfe3381b19b400e1bc97b5e8d66d2ac1d0a77c349ced3f) - A simple component that has the traffic light spacing built in so we can add things like sidebar collapse

<img width="242" height="91" alt="Screenshot 2025-08-26 at 10 13 23 AM" src="https://github.com/user-attachments/assets/8c2b4687-831e-4afc-bdf5-248d095733a6" />
<img width="205" height="89" alt="Screenshot 2025-08-26 at 10 13 29 AM" src="https://github.com/user-attachments/assets/cbe9cbf8-8986-4ae3-8144-cbb9fa86005a" />
<img width="205" height="90" alt="Screenshot 2025-08-26 at 10 22 01 AM" src="https://github.com/user-attachments/assets/ac6d5d36-ddd4-4863-9310-9e0d5d86a6ab" />
<img width="182" height="66" alt="Screenshot 2025-08-26 at 10 22 06 AM" src="https://github.com/user-attachments/assets/5bf4d55e-00cc-43a8-b4d8-42e1476c3320" />
