### PR TITLE
Fix for timeline item in dark mode

### DIFF
--- a/app/components/TimelineItem.tsx
+++ b/app/components/TimelineItem.tsx
@@ -61,7 +61,7 @@ export function TimelineItem({
               style={[
                 $titleText(themeName),
                 isImportant && $titleTextImportant(themeName),
-                { color: titleColor },
+                titleColor && { color: titleColor },
               ]}
               numberOfLines={1}
             >


### PR DESCRIPTION
The title color was always being overwritten by the prop, even when it was undefined, so the themed color was not set. 

Before:

<img width="652" height="674" alt="CleanShot 2025-08-26 at 20 18 23@2x" src="https://github.com/user-attachments/assets/eb81b55d-dbf3-44ac-9a70-1276c6950ece" />

After:

<img width="614" height="478" alt="CleanShot 2025-08-26 at 20 18 04@2x" src="https://github.com/user-attachments/assets/22959398-351a-406e-b2fd-a970b3fe05c3" />
