### PR TITLE
open in editor #34

### DIFF
--- a/app/components/StackFrameRow.tsx
+++ b/app/components/StackFrameRow.tsx
@@ -1,0 +1,108 @@
+import { useState } from "react"
+import { View, Text, Pressable, type ViewStyle, type TextStyle } from "react-native"
+import { themed } from "../theme/theme"
+import type { ErrorStackFrame } from "../types"
+import { isNodeModule, getJustFileName } from "../utils/stackFrames"
+
+interface StackFrameRowProps {
+  stackFrame: ErrorStackFrame
+  onPress: (fileName: string, lineNumber: number) => void
+}
+
+/**
+ * Renders a single stack frame row in a stack trace.
+ * Shows function name, file name, and line number.
+ * Dims node_modules entries and shows hover state.
+ */
+export function StackFrameRow({ stackFrame, onPress }: StackFrameRowProps) {
+  const [isHovered, setIsHovered] = useState(false)
+  const fileName = stackFrame.fileName || ""
+  const functionName = stackFrame.functionName || "(anonymous function)"
+  const lineNumber = stackFrame.lineNumber || 0
+  const isFromNodeModules = isNodeModule(fileName)
+  const justFileName = getJustFileName(fileName)
+
+  const handlePress = () => {
+    if (fileName) {
+      onPress(fileName, lineNumber)
+    }
+  }
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      onHoverIn={() => setIsHovered(true)}
+      onHoverOut={() => setIsHovered(false)}
+    >
+      <View
+        style={[
+          $container(),
+          isHovered ? $containerHovered() : {},
+          isFromNodeModules ? $containerNodeModules() : {},
+        ]}
+      >
+        <View style={$functionColumn()}>
+          <Text style={$functionText()} numberOfLines={1}>
+            {functionName}
+          </Text>
+        </View>
+        <View style={$fileColumn()}>
+          <Text style={$fileText()} numberOfLines={1}>
+            {justFileName}
+          </Text>
+        </View>
+        <View style={$lineColumn()}>
+          <Text style={$lineText()}>{lineNumber}</Text>
+        </View>
+      </View>
+    </Pressable>
+  )
+}
+
+const $container = themed<ViewStyle>(({ spacing }) => ({
+  flexDirection: "row",
+  paddingVertical: spacing.xs,
+  paddingHorizontal: spacing.sm,
+  cursor: "pointer",
+}))
+
+const $containerHovered = themed<ViewStyle>(({ colors }) => ({
+  backgroundColor: colors.neutralVery,
+}))
+
+const $containerNodeModules = themed<ViewStyle>(() => ({
+  opacity: 0.4,
+}))
+
+const $functionColumn = themed<ViewStyle>(() => ({
+  flex: 1,
+  marginRight: 8,
+}))
+
+const $fileColumn = themed<ViewStyle>(() => ({
+  flex: 1,
+  marginRight: 8,
+}))
+
+const $lineColumn = themed<ViewStyle>(() => ({
+  width: 60,
+  alignItems: "flex-end",
+}))
+
+const $functionText = themed<TextStyle>(({ colors, typography }) => ({
+  color: colors.mainText,
+  fontSize: typography.body,
+  fontFamily: typography.code.normal,
+}))
+
+const $fileText = themed<TextStyle>(({ colors, typography }) => ({
+  color: colors.neutral,
+  fontSize: typography.body,
+  fontFamily: typography.code.normal,
+}))
+
+const $lineText = themed<TextStyle>(({ colors, typography }) => ({
+  color: colors.primary,
+  fontSize: typography.body,
+  fontFamily: typography.code.normal,
+}))

--- a/app/state/sendCommand.ts
+++ b/app/state/sendCommand.ts
@@ -1,0 +1,22 @@
+import { sendToClient } from "./connectToServer"
+import { withGlobal } from "./useGlobal"
+
+/**
+ * Sends a command to the connected React Native client.
+ * This is used to trigger actions in the client app, such as opening files in the editor.
+ *
+ * @param type - The command type (e.g., "editor.open")
+ * @param payload - The command payload
+ * @param clientId - Optional client ID. If not provided, uses the active client.
+ */
+export function sendCommand(type: string, payload: any, clientId?: string) {
+  // If no clientId is provided, use the active client
+  const activeClientId = clientId || withGlobal("activeClientId", "")[0]
+
+  if (!activeClientId) {
+    console.warn("No active client to send command to")
+    return
+  }
+
+  sendToClient(type, payload, activeClientId)
+}

--- a/app/utils/stackFrames.ts
+++ b/app/utils/stackFrames.ts
@@ -1,0 +1,54 @@
+import type { ErrorStackFrame } from "../types"
+
+/**
+ * Type guard to check if stack is an array of ErrorStackFrame objects
+ */
+export function isErrorStackFrameArray(stack: any): stack is ErrorStackFrame[] {
+  if (!Array.isArray(stack)) return false
+  if (stack.length === 0) return false
+
+  const firstItem = stack[0]
+  return (
+    typeof firstItem === "object" &&
+    firstItem !== null &&
+    "fileName" in firstItem &&
+    "lineNumber" in firstItem
+  )
+}
+
+/**
+ * Formats a file name to show just the file name or the last few path segments
+ */
+export function formatFileName(fileName: string, segmentCount: number = 3): string {
+  if (!fileName) return ""
+
+  // Remove webpack:// prefix if present
+  const cleanedFileName = fileName.replace("webpack://", "")
+
+  const segments = cleanedFileName.split("/")
+  const lastSlashIndex = cleanedFileName.lastIndexOf("/")
+
+  // If it's just a filename with no path, return as-is
+  if (lastSlashIndex === -1) return cleanedFileName
+
+  // Return the last N segments
+  const shortPath = segments.slice(-segmentCount).join("/")
+  return shortPath
+}
+
+/**
+ * Checks if a file path is from node_modules
+ */
+export function isNodeModule(fileName: string): boolean {
+  if (!fileName) return false
+  return fileName.includes("/node_modules/")
+}
+
+/**
+ * Gets just the filename from a full path
+ */
+export function getJustFileName(fileName: string): string {
+  if (!fileName) return ""
+  const lastSlashIndex = fileName.lastIndexOf("/")
+  return lastSlashIndex > -1 ? fileName.substr(lastSlashIndex + 1) : fileName
+}


### PR DESCRIPTION
Implement Open In Editor functionality:

* Update standalone-server to be resilient to client disconnects
* Add StackFrameRow component to display stack frames
* Send "editor.open" command when stack frame is clicked

## manual testing

In your test app, place a throw new Error("some error") somewhere you can manually trigger it
In your test app reactotron config, make sure you have the following:
```typescript
  reactotron.useReactNative({
    networking: {
      ignoreUrls: /symbolicate/,
    },
    editor: false, // Disable the built-in editor plugin
    errors: {
      veto: (frame) => {
        // NOTE: Despite what the docs say, the implementation uses filter()
        // so return TRUE to KEEP the frame, FALSE to REMOVE it
        // Keep frames that are NOT from React Native internals
        return !(
          frame.fileName.includes("node_modules/react-native/") ||
          frame.fileName.includes("node_modules/@react-native/") ||
          frame.fileName.includes("node_modules/expo-router/") ||
          frame.fileName.includes("node_modules/@expo/") ||
          frame.fileName.includes("node_modules/metro/")
        )
      },
    },
  })

reactotron.use(openInEditor({ url: "http://localhost:8082/" })) // MAKE SURE THIS IS THE CORRECT PORT for the metro packager running the mobile app
```
Ensure you have EXPO_EDITOR or EDITOR set to a gui editor that can be called from the terminal.

closes #34 