### PR TITLE
fix(macOS): fix drag-to-resize bug in timeline divider

### DIFF
--- a/app/components/ResizableDivider.tsx
+++ b/app/components/ResizableDivider.tsx
@@ -1,6 +1,6 @@
 import { View, PanResponder, type ViewStyle } from "react-native"
 import { themed } from "../theme/theme"
-import { useRef, useState } from "react"
+import { useMemo, useState } from "react"
 
 type ResizableDividerProps = {
   onResize: (width: number) => void
@@ -17,32 +17,34 @@ export function ResizableDivider({
 }: ResizableDividerProps) {
   const [isDragging, setIsDragging] = useState(false)
 
-  const panResponder = useRef(
-    PanResponder.create({
-      onMoveShouldSetPanResponder: () => true,
-      onMoveShouldSetPanResponderCapture: () => true,
-      onPanResponderGrant: () => {
-        setIsDragging(true)
-      },
-      onPanResponderMove: (evt, gestureState) => {
-        // Calculate new width based on gesture
-        let newWidth = currentWidth + gestureState.dx
-        if (newWidth < minWidth) {
-          newWidth = minWidth
-        }
-        if (newWidth > maxWidth) {
-          newWidth = maxWidth
-        }
-        onResize(newWidth)
-      },
-      onPanResponderRelease: () => {
-        setIsDragging(false)
-      },
-      onPanResponderTerminate: () => {
-        setIsDragging(false)
-      },
-    }),
-  ).current
+  const panResponder = useMemo(
+    () =>
+      PanResponder.create({
+        onMoveShouldSetPanResponder: () => true,
+        onMoveShouldSetPanResponderCapture: () => true,
+        onPanResponderGrant: () => {
+          setIsDragging(true)
+        },
+        onPanResponderMove: (evt, gestureState) => {
+          // Calculate new width based on gesture relative to the current width
+          let newWidth = currentWidth + gestureState.dx
+          if (newWidth < minWidth) {
+            newWidth = minWidth
+          }
+          if (newWidth > maxWidth) {
+            newWidth = maxWidth
+          }
+          onResize(newWidth)
+        },
+        onPanResponderRelease: () => {
+          setIsDragging(false)
+        },
+        onPanResponderTerminate: () => {
+          setIsDragging(false)
+        },
+      }),
+    [currentWidth, minWidth, maxWidth, onResize],
+  )
 
   return <View {...panResponder.panHandlers} style={$divider(isDragging)} />
 }

--- a/app/components/ResizableDivider.tsx
+++ b/app/components/ResizableDivider.tsx
@@ -6,12 +6,14 @@ type ResizableDividerProps = {
   onResize: (width: number) => void
   minWidth?: number
   maxWidth?: number
+  currentWidth?: number
 }
 
 export function ResizableDivider({
   onResize,
   minWidth = 300,
   maxWidth = 800,
+  currentWidth = 300,
 }: ResizableDividerProps) {
   const [isDragging, setIsDragging] = useState(false)
 
@@ -24,7 +26,13 @@ export function ResizableDivider({
       },
       onPanResponderMove: (evt, gestureState) => {
         // Calculate new width based on gesture
-        const newWidth = Math.max(minWidth, Math.min(maxWidth, gestureState.moveX))
+        let newWidth = currentWidth + gestureState.dx
+        if (newWidth < minWidth) {
+          newWidth = minWidth
+        }
+        if (newWidth > maxWidth) {
+          newWidth = maxWidth
+        }
         onResize(newWidth)
       },
       onPanResponderRelease: () => {

--- a/app/screens/TimelineScreen.tsx
+++ b/app/screens/TimelineScreen.tsx
@@ -139,7 +139,12 @@ export function TimelineScreen() {
           ItemSeparatorComponent={Separator}
         />
       </View>
-      <ResizableDivider onResize={setTimelineWidth} minWidth={300} maxWidth={800} />
+      <ResizableDivider
+        currentWidth={timelineWidth}
+        onResize={setTimelineWidth}
+        minWidth={300}
+        maxWidth={800}
+      />
       <View style={$flex}>
         <DetailPanel selectedItem={selectedItem} onClose={() => setSelectedItemId(null)} />
       </View>

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1779,7 +1779,7 @@ SPEC CHECKSUMS:
   glog: b7594b792ee4e02ed1f44b01d046ca25fa713e3d
   hermes-engine: b5c9cfbe6415f1b0b24759f2942c8f33e9af6347
   IRNativeModules: 2fa316ab0ca91ec3e7bd4ba7ab2fc1f642fb5542
-  RCT-Folly: abec2d7f4af402b4957c44e86ceff8725b23c1b4
+  RCT-Folly: e8b53d8c0d2d9df4a6a8b0a368a1a91fc62a88cb
   RCTDeprecation: 9da6c2d8a3b1802142718283260fb06d702ddb07
   RCTRequired: 574f9d55bda1d50676530b6c36bab4605612dfb6
   RCTTypeSafety: 7de929c405e619c023116e7747118a2c5d5b2320


### PR DESCRIPTION
### Summary
Fix drag-to-resize bug affecting the timeline panel divider on macOS.

### Context & Motivation
Users reported that the timeline/details split view was difficult to resize and sometimes got stuck when dragging the divider. This change fixes the drag handling and edge clamping logic so the divider tracks the cursor reliably and respects minimum widths.

- Related: Closes #44

### Changes
- Improve divider drag handling and bounds checking in `ResizableDivider`
- Ensure `TimelineScreen` updates layout consistently during drag

### Diffstat
```text
 app/components/ResizableDivider.tsx | 10 +++++++++-
 app/screens/TimelineScreen.tsx      |  7 ++++++-
 macos/Podfile.lock                  |  2 +-
 3 files changed, 16 insertions(+), 3 deletions(-)
```

### Commits
- 3db970b — Steven Conner — 2025-10-09 — fix resize bug

### Breaking Changes
- None

### Screenshots (UI changes)
- N/A

### Notes
- Manual verification performed for drag behavior across the window width; divider now clamps to reasonable bounds and remains responsive.
